### PR TITLE
Only test Julia v1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
-          - 'nightly'
+          - '1'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
fixes #3 

I believe you just need to test the latest stable version for this package. You'll get a nice green check if these test pass and won't have to worry about the new breaking feature planned for Julia.